### PR TITLE
Fix dict_factory import

### DIFF
--- a/caspanda/bear.py
+++ b/caspanda/bear.py
@@ -7,7 +7,7 @@ and provides an interface between pandas and Cassandra.
 """
 from cassandra.cluster import Cluster
 from caspanda.metabear import ColumnMeta, KeyspaceMeta, TableMeta
-from cassandra.decoder import dict_factory
+from cassandra.query import dict_factory
 from cassandra.cluster import _shutdown_cluster
 
 from caspanda.bamboo import CassandraFrame


### PR DESCRIPTION
Hi there,

first, thanks for this nice library @aaronbenz.

In the newest `cassandra-driver` version, `dict_factory` is imported from `cassandra.query` instead of `cassandra.decoder`. This fixes the import error that occurs when trying to import CasPanda.

Cheers,
neocortex
