### PR TITLE
Made the library work with version 3 of the cassandra driver

### DIFF
--- a/caspanda/bear.py
+++ b/caspanda/bear.py
@@ -7,7 +7,7 @@ and provides an interface between pandas and Cassandra.
 """
 from cassandra.cluster import Cluster
 from caspanda.metabear import ColumnMeta, KeyspaceMeta, TableMeta
-from cassandra.decoder import dict_factory
+from cassandra.query import dict_factory
 from cassandra.cluster import _shutdown_cluster
 
 from caspanda.bamboo import CassandraFrame

--- a/caspanda/tests/test_input.py
+++ b/caspanda/tests/test_input.py
@@ -47,11 +47,10 @@ class TestQuery(BaseTestInput):
         self.frame.create_cql_insert()
 
 
-
-
     def test_all_attributes(self):
         self.frame.insert_async()
-        self.cf = self.session.execute("SELECT * FROM tester")
+        result_set = self.session.execute("SELECT * FROM tester") 
+        self.cf = result_set._current_rows
 
         self.assertEqual(len(self.cf), 3)
         self.assertIsInstance(self.cf, CassandraFrame)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name='caspanda',
-    version='0.0.0.3',
+    version='0.0.0.4',
     packages=find_packages(),
     install_requires=[
         'cassandra-driver',


### PR DESCRIPTION
Caspanda does not work with version of 3 of the driver. They have removed the "decoder" package and moved its functions to the "query" package.
https://datastax.github.io/python-driver/upgrading.html#deprecations

Also running session.execute() does not return a pandas DataFrame but an instance of ResultSet. Even though it's not too nice the only way I found to get the DataFrame from the ResultSet is result_set._current_rows
